### PR TITLE
Add update_cache to yum task

### DIFF
--- a/tasks/common_packages.yml
+++ b/tasks/common_packages.yml
@@ -4,7 +4,7 @@
   yum: name=epel-release state=latest
 
 - name: Install mysql-community-release
-  yum: name=http://repo.mysql.com/mysql-community-release-el7-7.noarch.rpm state=present
+  yum: name=http://repo.mysql.com/mysql-community-release-el7-7.noarch.rpm state=present update_cache=yes
 
 #################################################
 # Tasks to install common packages


### PR DESCRIPTION
In some cases if the base image has already installed epel repository there is a fail installing libmatheval packages.
Addinf update_cache to yum task is fixed.